### PR TITLE
99: Set Up GitHub Actions and Workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Bug Description**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual Behavior**
+A clear and concise description of what actually happens.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop**
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+**Smartphone**
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
+
+**Additional Context**
+Add any other context about the problem here.
+
+**Acceptance Criteria**
+- [ ] Enumeration of steps to be done in order to resolve the bug.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a feature for this project
+title: ''
+labels: feature
+assignees: ''
+
+---
+
+**Related Problem**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Solution**
+A clear and concise description of what you want to happen.
+
+**Considered Alternatives**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional Context**
+Add any other context or screenshots about the feature request here.
+
+**Acceptance Criteria**
+- [ ] Enumeration of steps to be done in order to resolve the feature request.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,20 @@
+---
+name: Task
+about: Generic work to be done, not directly related to new features
+title: ''
+labels: task
+assignees: ''
+
+---
+
+**Description**
+A clear and concise description of what needs to be done.
+
+**Related Problem**
+A clear and concise description of what the problem is or why the work needs to be done.
+
+**Additional Context**
+Add any other context or screenshots about the task here.
+
+**Acceptance Criteria**
+- [ ] Enumeration of steps to be done in order to resolve the task.

--- a/.github/issue-branch.yml
+++ b/.github/issue-branch.yml
@@ -1,0 +1,40 @@
+# see https://github.com/robvanderleek/create-issue-branch
+
+# The default mode is "auto", meaning a new issue branch is created after an issue is assigned.
+# The mode "chatops" means a new issue branch is created after commenting on an issue with /create-issue-branch or /cib.
+mode: chatops
+
+# by default, the repository's default branch is used to fork issue branches off of (i.e. main), property 'defaultBranch' overrides this
+defaultBranch: 'develop'
+
+# tiny (i15), short (issue-15), full (issue-15-fix-nasty-bug) or custom
+# see also https://github.com/robvanderleek/create-issue-branch/blob/master/tests/test-fixtures/issues.assigned.json
+# for available fields
+#
+# Substitutions for ${...} placeholders can be lowercased by putting a , before the closing curly brace.
+# Likewise, substitutions can be uppercased by putting a ^ before the closing curly brace.
+branchName: '${issue.number}-${issue.title,}'
+#branchName: '${issue.number}-${issue.title^}'
+
+# true: comments on the issue after creating a branch
+# false: does not comment on the issue after creating a branch
+silent: false
+
+# characters that are not allowed in Git branch names are replaced by this character
+gitSafeReplacementChar: '-'
+
+# uncomment lines below if branches with the task, feature, bug and documentation labels should have corresponding prefixes
+# create branch from development as source branch
+#branches:
+#  - label: task
+#    name: develop
+#    prefix: task/
+#  - label: feature
+#    name: develop
+#    prefix: feature/
+#  - label: bug
+#    name: develop
+#    prefix: bugfix/
+
+# Automatically close issue after pull request is merged.
+autoCloseIssue: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,177 @@
+name: CI (Ubuntu)
+
+env:
+  # This will suppress any download for dependencies and plugins or upload messages which would clutter the console log.
+  # `showDateTime` will show the passed time in milliseconds. You need to specify `--batch-mode` to make this work.
+  MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
+  # As of Maven 3.3.0 instead of this you may define these options in `.mvn/maven.config` so the same config is used
+  # when running from the command line.
+  # `installAtEnd` and `deployAtEnd` are only effective with recent version of the corresponding plugins.
+  MAVEN_CLI_OPTS: "--batch-mode --errors --fail-at-end --show-version -DinstallAtEnd=true -DdeployAtEnd=true"
+
+# run CI builds for main and develop branches, as well as pull requests targeting the main or development branch
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  # allow triggering CI runs manually via GitHub UI
+  workflow_dispatch:
+
+jobs:
+  check-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          java-version: 15
+          distribution: 'adopt'
+          cache: 'maven' # see also https://github.com/actions/setup-java#caching-packages-dependencies
+
+      # Even though setup-java already offers the ability to run maven builds, using the included
+      # Maven wrapper with fixed version ensures a uniform build process across multiple tools
+      - name: Make Maven Wrapper Executable
+        run: |
+          cd server
+          chmod +x mvnw
+
+      - name: Execute Maven checkstyle Plugin
+        run: |
+          cd server
+          ./mvnw $MAVEN_CLI_OPTS checkstyle:check
+
+  check-client:
+    runs-on: ubuntu-latest
+    container: "cirrusci/flutter:2.10.0"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Client Dependencies and Run Code Generation
+        run: |
+          cd client
+          flutter doctor --verbose
+          flutter clean
+          flutter pub get
+          flutter pub run build_runner build
+
+      # Applies code formatting to project using dartfmt. Redirect stderr (2) to stdout (1) and send it to a file. If
+      # this output (i.e. the formatted files) contains at least one line that ends with .dart, but NOT with .g.dart or .mocks.dart
+      # (generated files may be formatted differently), exit with code 1, making the job fail.
+      - name: Check Code Formatting
+        run: |
+          cd client
+          dart format ./ --line-length 150 > formatResult.txt 2>&1 || true
+          cat formatResult.txt
+          while IFS="" read -r line || [ -n "$line" ]
+          do
+            if echo "$line" | grep --quiet ".dart"
+            then
+              if ! echo "$line" | grep --quiet ".g.dart"
+              then
+                if ! echo "$line" | grep --quiet ".mocks.dart"
+                then
+                  echo "INCORRECTLY FORMATTED FILE: $line"
+                  exit 1
+                fi
+              fi
+            fi
+          done < formatResult.txt
+
+      # The 'flutter analyze' may print parts of its output to stderr. Therefore, redirect stderr (2) to
+      # stdout (1) and send it to a file. Finally, grep it for a positive outcome ("No issues found"). If this string
+      # is not found (i.e. there are issues), grep exits with code 1, making the job fail. The " || true" part makes
+      # that a potential non-zero exit code produced by the flutter analyze command does not make the job fail prematurely.
+      - name: Check Linter Rules
+        run: |
+          cd client
+          flutter analyze > analysisResult.txt 2>&1 || true
+          cat analysisResult.txt
+          grep "No issues found" analysisResult.txt
+
+
+  test-server:
+    if: ${{ always() }}
+    needs: [check-server]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          java-version: 15
+          distribution: 'adopt'
+          cache: 'maven' # see also https://github.com/actions/setup-java#caching-packages-dependencies
+
+      # Even though setup-java already offers the ability to run maven builds, using the included
+      # Maven wrapper with fixed version ensures a uniform build process across multiple tools
+      - name: Make Maven Wrapper Executable
+        run: |
+          cd server
+          chmod +x mvnw
+
+      - name: Run Java Unit and Integration Tests
+        run: |
+          cd server
+          ./mvnw $MAVEN_CLI_OPTS clean verify
+
+      - name: Upload Build Artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-server-artifacts
+          # Filename of server_api.(json|yaml) of API artifacts has to be kept in sync with the value of the LOCAL_FILE_NAME
+          # constant in the server/src/test/java/com/witness/server/integration/web/ApiGenerationTest.java file.
+          path: |
+            ./server/logs
+            ./server/target/surefire-reports/
+            ./server/server_api.json
+            ./server/server_api.yaml
+
+  test-client:
+    if: ${{ always() }}
+    needs: [check-client]
+    runs-on: ubuntu-latest
+    container: "cirrusci/flutter:2.10.0"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Client Dependencies and Run Code Generation
+        run: |
+          cd client
+          flutter doctor --verbose
+          flutter clean
+          flutter pub get
+          flutter pub run build_runner build
+
+      - name: Activate Reporter Pub Packages
+        run: |
+          export PATH="$PATH":"$HOME/.pub-cache/bin"
+          cd client
+          flutter pub global activate dart_dot_reporter
+          flutter pub global activate junitreport
+
+      # Execute tests, save JSON output to file. junitreport converts the very verbose, raw JSON output into a more readable XML format
+      # for further examinations. dart_dot_reporter creates a nice summary of the test execution from the JSON output for the CI logs.
+      - name: Run Flutter Unit and Integration Tests
+        run: |
+          cd client
+          flutter test --machine > flutter-test-report-raw.json || echo "[ERROR] Flutter Tests failed! See build artifacts for more details."
+          flutter pub global run junitreport:tojunit --input flutter-test-report-raw.json --output flutter-test-report.xml
+          flutter pub global run dart_dot_reporter flutter-test-report-raw.json --show-message --show-success --show-id
+
+      - name: Upload Build Artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-client-artifacts
+          path: |
+            ./client/flutter-test-report-raw.json
+            ./client/flutter-test-report.xml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,8 @@ check:server:
   stage: check
   script:
     - 'cd server'
-    - 'mvn $MAVEN_CLI_OPTS checkstyle:check'
+    - 'chmod +x mvnw'
+    - './mvnw $MAVEN_CLI_OPTS checkstyle:check'
 
 # Check codestyle, linting and static analysis of client code with dartfmt
 check:client:
@@ -37,16 +38,30 @@ check:client:
   stage: check
   script:
     - 'cd client'
+    - 'flutter doctor --verbose'
     - 'flutter clean'
     - 'flutter pub get'
     - 'flutter pub run build_runner build'
 
     # Applies code formatting to project using dartfmt. Redirect stderr (2) to stdout (1) and send it to a file. If
     # this output (i.e. the formatted files) contains at least one line that ends with .dart, but NOT with .g.dart or .mocks.dart
-    # (generated files may be formatted differently), the command on the last line returns 1, making the job fail.
+    # (generated files may be formatted differently), exit with code 1, making the job fail.
     - 'dart format ./ --line-length 150 > formatResult.txt 2>&1 || true'
     - 'cat formatResult.txt'
-    - if [ $(grep --perl-regexp 'Formatted[[:space:]].*(?<!\.(g|mocks))\.dart' formatResult.txt -c) != 0 ]; then exit 1; fi
+    - while IFS="" read -r line || [ -n "$line" ]
+      do
+        if echo "$line" | grep --quiet ".dart"
+        then
+          if ! echo "$line" | grep --quiet ".g.dart"
+          then
+            if ! echo "$line" | grep --quiet ".mocks.dart"
+            then
+              echo "INCORRECTLY FORMATTED FILE: $line"
+              exit 1
+            fi
+          fi
+        fi
+      done < formatResult.txt
 
     # The 'flutter analyze' may print parts of its output to stderr. Therefore, redirect stderr (2) to
     # stdout (1) and send it to a file. Finally, grep it for a positive outcome ("No issues found"). If this string
@@ -65,7 +80,8 @@ test:server:
   when: always
   script:
     - 'cd server'
-    - 'mvn $MAVEN_CLI_OPTS clean verify'
+    - 'chmod +x mvnw'
+    - './mvnw $MAVEN_CLI_OPTS clean verify'
   artifacts:
     when: always
     paths:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+| [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) | `main`                                                                                                               | `develop`                                                                                                               |
+|-----------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| CI Status                                                                                                 | ![example branch parameter](https://github.com/witness-org/witness/actions/workflows/main.yml/badge.svg?branch=main) | ![example branch parameter](https://github.com/witness-org/witness/actions/workflows/main.yml/badge.svg?branch=develop) |
+| Test Coverage (server)                                                                                    | TBD                                                                                                                  | TBD                                                                                                                     |
+| Test Coverage (client)                                                                                    | TBD                                                                                                                  | TBD                                                                                                                     |
+
 # witness
 
 This project aims to provide an application to be used by weightlifters to log their workouts, monitor their progress


### PR DESCRIPTION
Closes #99.

---

Quick facts:

* I have set up branch protection rules for `main` and `develop` (e.g. linear history, CI green, at least 1 review)
  * the rules for `develop` are a bit less strict, i.e. the two of us may circumvent those rules
  * for `main`, we would have to deliberately turn it off temporarily if we'd like to ignore the rules
* migration log:
  * issues have been thoroughly migrated (open and closed ones), including comments (excluding time logs)
  * wiki has been migrated according to your specification
  * milestones and labels have been migrated (but lowercased, as per GitHub conventions)
  * PRs could **not** be migrated because they were already merged
    * instead, closed issues were created for them with the label `gitlab merge request`, including our discussions (which might be worth something)
    * if you want to filter closed issues, but ignore merge request issues, use the query `is:issue is:closed -label:"gitlab merge request"` (i.e. just press the respective buttons in the GitHub UI and insert a **-** before `label` in order to _exclude_ issues with label `gitlab merge request`)
    * organization administrators (you and me) might completely delete issues - so if you deem the issues absolutely worthless, we could also delete them
  * snippets have been migrated as dedicated wiki page (which is fitting because we did not use snippets as intened by GitLab, anyway )
* the `grep` with pearl regex for `check-client` did not work (neither in GitLab nor in GitHub), I had to fix it with a `sh`-compatible script because I did not want to be frustrated with grep and PCRE anymore
  * `sh` is a requirement because CI jobs don't run in `bash` which takes away some nice syntactic sugars
  * please note that I did not know how to express `if A && (!B && !C)` more succinctly in a `sh`-compatible way - it took me already quite some time to get it working as is - so I'd like to keep it a bit more verbose for now
  * but feel free to ask me via DM about what exactly failed (in GitLab and GitHub), why we didn't notice and what struggles I had to overcome to arrive at the current solution
* the GitHub CI is essentially equivalent to the one we had at GitLab - you can see them along with badges etc in the readme as soon as everything is merged to `main`.  until then, you can view some past actions in the Actions tab - there you have build logs, artifacts, dependencies between jobs etc.
* I added issue templates for different kinds of tickets (bug, feature, task) along with some help text. You can try it out as soon as everything is merged to main. Until then, look at the follow-up issue #100 for an example of the `task` template.
  * if you absolutely hate them, we can remove them. However, I like this feature because it gives you some suggestions when formulating issues. **Note**, that I **don't** intend to have this as as guideline, i.e. that every feature must conform to at least one such template. If you just create a quick issue, just delete everything and give a short textual explanation. I just like those templates to give you some kind of structure (if you want) - in my opinion, it also helps you break everything down and think about what you want to achieve with an issue. But, as I said, you are always free to use as much or as little of those templates as you want.
* One, in my opinion, quite serious blunder on GitHub's side is that you don't have a feature like GitLab's "Create Branch" directly from an issue. That's why I have included and configured the `create-issue-branch` action (also have a look at the repository settings under `Integrations -> GitHub Apps` where it had to be activated first). It doesn't give the exact same workflow as in GitLab, but essentially achieves the same - you simply have to comment `/cib` on an issue. This way, we easily get _consistently named_  (for the future and also consistent with how GitLab did it) feature branches.
* you should have been added to the organization and the @witness-org/core-maintainers team. the team simplifies managing roles and privileges for multiple people. for the `witness` repository, @witness-org/core-maintainers is `admin` which is the ultimate reason why we are able to bypass some rules for the develop branch (and why you should automatically have been added to repository, without me explicitly adding you, as a person - but because you are part of the team)
* **Caveat**: The only thing that could not be migrated automatically are attachments, i.e. files and images, to comments, issues and so on (it would have been possible, but only with an AWS S3 bucket as intermediary storage and I did not want to create one). I did it manually for the Wiki (obviously, it's important there), but did not do so for past/closed issues and merge requests. If you would like to have that, I kindly ask you to do so yourself (i.e. download image or file from gitlab, edit comment in github and replace gitlab file reference by newly uploaded file/image in github) - e.g. for images in closed merge requests or your UI sketches for logging workouts.

Question for you: Is there anything left we need from GitLab or was I able to migrate everything relevant? In other words, can the GitLab project be archived?